### PR TITLE
added ie11-polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,5 @@ export default function(Vue) {
 }
 
 export function timer(name, time, options) {
-  return Object.assign({ name: name, time: time }, options)
+  return mixin.assign({ name: name, time: time }, options)
 }

--- a/mixin.js
+++ b/mixin.js
@@ -1,3 +1,4 @@
+// jshint esversion: 6, asi: true
 import { set } from './utils'
 
 function generateData(timers) {
@@ -135,5 +136,21 @@ export default {
     Object.keys(vm.$options.timers).forEach(function(key) {
       vm.$timer.stop(key)
     })
+  },
+
+  /**
+   * Polyfill for Object.assign for IE11 support
+   */
+  assign: function (){
+    var assign = Object.assign || function assign(to) {
+      for (var s = 1; s < arguments.length; s += 1) {
+        var from = arguments[s]
+        for (var key in from) {
+          to[key] = from[key]
+        }
+      }
+      return to
+    }
+    return assign
   }
 }


### PR DESCRIPTION
Object.assign isn't supported by IE11.

See reference:
https://stackoverflow.com/questions/42091600/how-to-merge-object-in-ie-11?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa